### PR TITLE
Fix null field update in baseMapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,244 @@
-# test
+# MyBatis-Plus updateById null字段更新问题解决方案
+
+## 问题描述
+
+使用 MyBatis-Plus 的 `baseMapper.updateById(entity)` 方法时，如果实体对象的某些字段值为 `null`，这些字段不会被更新到数据库。
+
+### 问题原因
+
+MyBatis-Plus 的默认字段更新策略是 `FieldStrategy.NOT_NULL`，即只更新非 null 的字段。这是为了防止误操作将数据库中的有效数据更新为 null。
+
+## 项目结构
+
+```
+mybatis-plus-null-update/
+├── pom.xml                          # Maven配置文件
+├── src/main/java/com/example/
+│   ├── Application.java             # 主启动类
+│   ├── entity/
+│   │   └── User.java               # 用户实体类（演示不同更新策略）
+│   ├── mapper/
+│   │   └── UserMapper.java         # Mapper接口（包含自定义SQL）
+│   ├── service/
+│   │   └── UserService.java        # 服务层（多种解决方案实现）
+│   ├── controller/
+│   │   └── UserController.java     # 控制器（REST API）
+│   ├── config/
+│   │   └── MyBatisPlusConfig.java  # MyBatis-Plus配置
+│   └── solutions/
+│       └── UpdateNullSolutionDemo.java  # 解决方案详细说明
+├── src/main/resources/
+│   ├── application.yml              # 应用配置
+│   └── schema.sql                   # 数据库初始化脚本
+└── src/test/java/com/example/
+    └── UpdateNullFieldTest.java    # 测试用例
+
+```
+
+## 快速开始
+
+### 1. 运行项目
+
+```bash
+# 克隆或下载项目后，进入项目目录
+cd /workspace
+
+# 使用Maven运行项目
+mvn spring-boot:run
+
+# 或者先编译再运行
+mvn clean package
+java -jar target/mybatis-plus-null-update-1.0.0.jar
+```
+
+### 2. 访问H2控制台
+
+项目启动后，访问 H2 数据库控制台：
+- URL: http://localhost:8080/h2-console
+- JDBC URL: `jdbc:h2:mem:testdb`
+- Username: `sa`
+- Password: (留空)
+
+### 3. 运行测试
+
+```bash
+# 运行所有测试
+mvn test
+
+# 运行特定测试类
+mvn test -Dtest=UpdateNullFieldTest
+```
+
+## 解决方案汇总
+
+### 方案1：实体字段注解配置
+
+```java
+// 在实体类字段上使用 @TableField 注解
+@TableField(updateStrategy = FieldStrategy.IGNORED)
+private String phone;  // 该字段会更新null值
+```
+
+**适用场景**：某个字段总是需要更新null值
+
+### 方案2：使用 UpdateWrapper
+
+```java
+// 使用 LambdaUpdateWrapper（推荐）
+LambdaUpdateWrapper<User> wrapper = Wrappers.<User>lambdaUpdate()
+    .eq(User::getId, userId)
+    .set(User::getEmail, null)      // 明确设置为null
+    .set(User::getPhone, null);     // 明确设置为null
+    
+userService.update(wrapper);
+```
+
+**适用场景**：偶尔需要更新null值，灵活控制
+
+### 方案3：全局配置
+
+```yaml
+# application.yml
+mybatis-plus:
+  global-config:
+    db-config:
+      update-strategy: ignored  # 全局更新null值（慎用）
+```
+
+**适用场景**：整个项目都需要更新null值（不推荐）
+
+### 方案4：自定义SQL
+
+```java
+@Update("UPDATE user SET email = #{email}, phone = #{phone} WHERE id = #{id}")
+int updateWithNull(@Param("id") Long id, 
+                  @Param("email") String email, 
+                  @Param("phone") String phone);
+```
+
+**适用场景**：复杂业务逻辑，需要精确控制SQL
+
+### 方案5：使用 allEq 方法
+
+```java
+UpdateWrapper<User> wrapper = new UpdateWrapper<>();
+Map<String, Object> updateMap = new HashMap<>();
+updateMap.put("email", null);
+updateMap.put("phone", null);
+
+wrapper.eq("id", userId)
+       .allEq(updateMap, true);  // true表示包含null值
+```
+
+**适用场景**：批量字段更新
+
+## API 接口测试
+
+### 1. 创建用户
+
+```bash
+curl -X POST http://localhost:8080/user/create \
+  -H "Content-Type: application/json" \
+  -d '{
+    "username": "测试用户",
+    "email": "test@example.com",
+    "phone": "13800138000"
+  }'
+```
+
+### 2. 默认更新（null不更新）
+
+```bash
+curl -X PUT http://localhost:8080/user/update/default \
+  -H "Content-Type: application/json" \
+  -d '{
+    "id": 1,
+    "email": null,
+    "phone": null,
+    "address": "新地址"
+  }'
+```
+
+### 3. 使用UpdateWrapper更新（null会更新）
+
+```bash
+curl -X PUT http://localhost:8080/user/update/wrapper/1 \
+  -H "Content-Type: application/json" \
+  -d '{
+    "email": null,
+    "phone": null,
+    "address": "新地址"
+  }'
+```
+
+### 4. 清空特定字段
+
+```bash
+curl -X PUT http://localhost:8080/user/clear/1/email
+```
+
+### 5. 动态更新
+
+```bash
+# forceUpdateNull=true 时更新null值
+curl -X PUT "http://localhost:8080/user/update/dynamic?forceUpdateNull=true" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "id": 1,
+    "email": null,
+    "phone": null
+  }'
+```
+
+## 最佳实践建议
+
+### 1. 选择合适的方案
+
+| 场景 | 推荐方案 | 原因 |
+|-----|---------|------|
+| 偶尔更新null | UpdateWrapper | 灵活控制，不影响其他操作 |
+| 特定字段常更新null | @TableField注解 | 配置简单，针对性强 |
+| 复杂业务逻辑 | 自定义SQL | 完全控制，性能最优 |
+| 批量更新 | allEq方法 | 代码简洁，易于维护 |
+
+### 2. 注意事项
+
+1. **避免全局IGNORED策略**：可能导致意外的null更新
+2. **使用LambdaWrapper**：类型安全，避免字段名拼写错误
+3. **明确业务需求**：区分"不更新"和"更新为null"
+4. **添加单元测试**：验证null更新行为
+5. **代码注释**：说明null值处理策略
+
+### 3. 性能优化
+
+- 优先使用 UpdateWrapper（单次数据库操作）
+- 避免先查后更（两次数据库操作）
+- 批量更新考虑使用批处理
+
+## 常见问题
+
+### Q1: 为什么MyBatis-Plus默认不更新null字段？
+
+**A**: 这是一种保护机制，防止误操作将数据库中的有效数据更新为null。在实际业务中，大部分情况下我们不希望将字段更新为null。
+
+### Q2: 使用IGNORED策略有什么风险？
+
+**A**: 如果全局或字段级别设置IGNORED策略，所有的更新操作都会包含null值，可能会意外地将数据库中的有效数据清空。
+
+### Q3: UpdateWrapper和updateById性能有差异吗？
+
+**A**: 性能差异很小。UpdateWrapper提供了更灵活的控制，而updateById在简单场景下代码更简洁。
+
+### Q4: 如何只更新部分字段为null？
+
+**A**: 使用UpdateWrapper的set方法，只对需要更新为null的字段调用set方法。
+
+## 相关资源
+
+- [MyBatis-Plus 官方文档](https://baomidou.com/)
+- [字段策略说明](https://baomidou.com/pages/223848/)
+- [UpdateWrapper 使用指南](https://baomidou.com/pages/10c804/)
+
+## License
+
+MIT

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>2.7.14</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.example</groupId>
+    <artifactId>mybatis-plus-null-update</artifactId>
+    <version>1.0.0</version>
+    <name>mybatis-plus-null-update</name>
+    <description>Demo for MyBatis-Plus null field update issue</description>
+
+    <properties>
+        <java.version>1.8</java.version>
+        <mybatis-plus.version>3.5.3.2</mybatis-plus.version>
+    </properties>
+
+    <dependencies>
+        <!-- Spring Boot Starter Web -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <!-- MyBatis-Plus -->
+        <dependency>
+            <groupId>com.baomidou</groupId>
+            <artifactId>mybatis-plus-boot-starter</artifactId>
+            <version>${mybatis-plus.version}</version>
+        </dependency>
+
+        <!-- MySQL Driver -->
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- H2 Database for testing -->
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- Lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Spring Boot Test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/Application.java
+++ b/src/main/java/com/example/Application.java
@@ -1,0 +1,21 @@
+package com.example;
+
+import org.mybatis.spring.annotation.MapperScan;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * 应用程序主类
+ */
+@SpringBootApplication
+@MapperScan("com.example.mapper")
+public class Application {
+    
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+        System.out.println("\n========================================");
+        System.out.println("应用启动成功！");
+        System.out.println("H2控制台: http://localhost:8080/h2-console");
+        System.out.println("========================================\n");
+    }
+}

--- a/src/main/java/com/example/config/MyBatisPlusConfig.java
+++ b/src/main/java/com/example/config/MyBatisPlusConfig.java
@@ -1,0 +1,34 @@
+package com.example.config;
+
+import com.baomidou.mybatisplus.core.handlers.MetaObjectHandler;
+import org.apache.ibatis.reflection.MetaObject;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.LocalDateTime;
+
+/**
+ * MyBatis-Plus 配置类
+ */
+@Configuration
+public class MyBatisPlusConfig {
+    
+    /**
+     * 自动填充处理器
+     */
+    @Bean
+    public MetaObjectHandler metaObjectHandler() {
+        return new MetaObjectHandler() {
+            @Override
+            public void insertFill(MetaObject metaObject) {
+                this.strictInsertFill(metaObject, "createTime", LocalDateTime.class, LocalDateTime.now());
+                this.strictInsertFill(metaObject, "updateTime", LocalDateTime.class, LocalDateTime.now());
+            }
+            
+            @Override
+            public void updateFill(MetaObject metaObject) {
+                this.strictUpdateFill(metaObject, "updateTime", LocalDateTime.class, LocalDateTime.now());
+            }
+        };
+    }
+}

--- a/src/main/java/com/example/controller/UserController.java
+++ b/src/main/java/com/example/controller/UserController.java
@@ -1,0 +1,139 @@
+package com.example.controller;
+
+import com.example.entity.User;
+import com.example.service.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 用户控制器
+ * 演示不同的更新方式
+ */
+@RestController
+@RequestMapping("/user")
+public class UserController {
+    
+    @Autowired
+    private UserService userService;
+    
+    /**
+     * 创建用户
+     */
+    @PostMapping("/create")
+    public Map<String, Object> createUser(@RequestBody User user) {
+        Map<String, Object> result = new HashMap<>();
+        boolean success = userService.save(user);
+        result.put("success", success);
+        result.put("message", success ? "创建成功" : "创建失败");
+        if (success) {
+            result.put("userId", user.getId());
+        }
+        return result;
+    }
+    
+    /**
+     * 获取用户
+     */
+    @GetMapping("/{id}")
+    public User getUser(@PathVariable Long id) {
+        return userService.getById(id);
+    }
+    
+    /**
+     * 方案1：使用默认的updateById（null字段不更新）
+     */
+    @PutMapping("/update/default")
+    public Map<String, Object> updateDefault(@RequestBody User user) {
+        Map<String, Object> result = new HashMap<>();
+        boolean success = userService.updateByIdDefault(user);
+        result.put("success", success);
+        result.put("method", "updateById (默认方式)");
+        result.put("description", "null字段不会被更新到数据库");
+        return result;
+    }
+    
+    /**
+     * 方案2：使用UpdateWrapper
+     */
+    @PutMapping("/update/wrapper/{id}")
+    public Map<String, Object> updateByWrapper(@PathVariable Long id, @RequestBody User user) {
+        Map<String, Object> result = new HashMap<>();
+        boolean success = userService.updateByWrapperWithNull(id, user);
+        result.put("success", success);
+        result.put("method", "UpdateWrapper");
+        result.put("description", "使用set方法可以将字段更新为null");
+        return result;
+    }
+    
+    /**
+     * 方案3：使用LambdaUpdateWrapper
+     */
+    @PutMapping("/update/lambda/{id}")
+    public Map<String, Object> updateByLambda(@PathVariable Long id, @RequestBody User user) {
+        Map<String, Object> result = new HashMap<>();
+        boolean success = userService.updateByLambdaWrapper(id, user);
+        result.put("success", success);
+        result.put("method", "LambdaUpdateWrapper");
+        result.put("description", "类型安全的方式，可以将字段更新为null");
+        return result;
+    }
+    
+    /**
+     * 方案4：使用自定义SQL
+     */
+    @PutMapping("/update/custom")
+    public Map<String, Object> updateByCustom(@RequestBody User user) {
+        Map<String, Object> result = new HashMap<>();
+        boolean success = userService.updateByCustomSql(user);
+        result.put("success", success);
+        result.put("method", "自定义SQL");
+        result.put("description", "完全控制SQL语句，可以更新null");
+        return result;
+    }
+    
+    /**
+     * 方案5：先查询再更新
+     */
+    @PutMapping("/update/select-first")
+    public Map<String, Object> updateBySelectFirst(@RequestBody User user) {
+        Map<String, Object> result = new HashMap<>();
+        boolean success = userService.updateBySelectFirst(user);
+        result.put("success", success);
+        result.put("method", "先查询再更新");
+        result.put("description", "需要两次数据库操作，性能较差");
+        return result;
+    }
+    
+    /**
+     * 方案6：清空某个字段
+     */
+    @PutMapping("/clear/{id}/{fieldName}")
+    public Map<String, Object> clearField(@PathVariable Long id, @PathVariable String fieldName) {
+        Map<String, Object> result = new HashMap<>();
+        boolean success = userService.clearField(id, fieldName);
+        result.put("success", success);
+        result.put("method", "清空字段");
+        result.put("description", "将指定字段设置为null");
+        result.put("field", fieldName);
+        return result;
+    }
+    
+    /**
+     * 方案7：动态更新
+     */
+    @PutMapping("/update/dynamic")
+    public Map<String, Object> updateDynamic(
+            @RequestBody User user,
+            @RequestParam(defaultValue = "false") boolean forceUpdateNull) {
+        Map<String, Object> result = new HashMap<>();
+        boolean success = userService.updateDynamic(user, forceUpdateNull);
+        result.put("success", success);
+        result.put("method", "动态SQL");
+        result.put("description", "通过参数控制是否更新null值");
+        result.put("forceUpdateNull", forceUpdateNull);
+        return result;
+    }
+}

--- a/src/main/java/com/example/entity/User.java
+++ b/src/main/java/com/example/entity/User.java
@@ -1,0 +1,89 @@
+package com.example.entity;
+
+import com.baomidou.mybatisplus.annotation.*;
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import java.time.LocalDateTime;
+
+/**
+ * 用户实体类
+ * 演示 MyBatis-Plus updateById 字段为null未更新的问题
+ */
+@Data
+@Accessors(chain = true)
+@TableName("user")
+public class User {
+    
+    /**
+     * 主键ID
+     */
+    @TableId(type = IdType.AUTO)
+    private Long id;
+    
+    /**
+     * 用户名
+     */
+    private String username;
+    
+    /**
+     * 密码
+     */
+    private String password;
+    
+    /**
+     * 邮箱
+     * 默认策略：NOT_NULL - 当字段为null时不会更新
+     */
+    private String email;
+    
+    /**
+     * 手机号
+     * 使用 @TableField 注解指定更新策略为 IGNORED
+     * 这样即使字段为null也会被更新
+     */
+    @TableField(updateStrategy = FieldStrategy.IGNORED)
+    private String phone;
+    
+    /**
+     * 地址
+     * 使用 @TableField 注解，可以动态控制更新策略
+     */
+    @TableField(updateStrategy = FieldStrategy.DEFAULT)
+    private String address;
+    
+    /**
+     * 年龄
+     */
+    private Integer age;
+    
+    /**
+     * 状态（0：禁用，1：启用）
+     */
+    private Integer status;
+    
+    /**
+     * 备注
+     * 演示使用 condition 条件控制
+     */
+    @TableField(condition = SqlCondition.LIKE)
+    private String remark;
+    
+    /**
+     * 创建时间
+     */
+    @TableField(fill = FieldFill.INSERT)
+    private LocalDateTime createTime;
+    
+    /**
+     * 更新时间
+     */
+    @TableField(fill = FieldFill.INSERT_UPDATE)
+    private LocalDateTime updateTime;
+    
+    /**
+     * 逻辑删除标志
+     */
+    @TableLogic
+    private Integer deleted;
+}

--- a/src/main/java/com/example/mapper/UserMapper.java
+++ b/src/main/java/com/example/mapper/UserMapper.java
@@ -1,0 +1,58 @@
+package com.example.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.example.entity.User;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Update;
+
+/**
+ * 用户Mapper接口
+ */
+@Mapper
+public interface UserMapper extends BaseMapper<User> {
+    
+    /**
+     * 自定义SQL更新，可以更新null字段
+     * 
+     * @param user 用户对象
+     * @return 影响行数
+     */
+    @Update("UPDATE user SET " +
+            "username = #{user.username}, " +
+            "password = #{user.password}, " +
+            "email = #{user.email}, " +
+            "phone = #{user.phone}, " +
+            "address = #{user.address}, " +
+            "age = #{user.age}, " +
+            "status = #{user.status}, " +
+            "remark = #{user.remark} " +
+            "WHERE id = #{user.id}")
+    int updateByIdWithNull(@Param("user") User user);
+    
+    /**
+     * 选择性更新某些字段为null
+     */
+    @Update("UPDATE user SET email = null WHERE id = #{id}")
+    int setEmailToNull(@Param("id") Long id);
+    
+    /**
+     * 动态SQL更新
+     */
+    @Update("<script>" +
+            "UPDATE user " +
+            "<set>" +
+            "    <if test='user.username != null or forceNull'>" +
+            "        username = #{user.username}," +
+            "    </if>" +
+            "    <if test='user.email != null or forceNull'>" +
+            "        email = #{user.email}," +
+            "    </if>" +
+            "    <if test='user.phone != null or forceNull'>" +
+            "        phone = #{user.phone}," +
+            "    </if>" +
+            "</set>" +
+            "WHERE id = #{user.id}" +
+            "</script>")
+    int updateDynamic(@Param("user") User user, @Param("forceNull") boolean forceNull);
+}

--- a/src/main/java/com/example/service/UserService.java
+++ b/src/main/java/com/example/service/UserService.java
@@ -1,0 +1,161 @@
+package com.example.service;
+
+import com.baomidou.mybatisplus.core.conditions.update.LambdaUpdateWrapper;
+import com.baomidou.mybatisplus.core.conditions.update.UpdateWrapper;
+import com.baomidou.mybatisplus.core.toolkit.Wrappers;
+import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.example.entity.User;
+import com.example.mapper.UserMapper;
+import org.springframework.stereotype.Service;
+
+/**
+ * 用户服务类
+ * 提供多种解决 null 字段更新的方案
+ */
+@Service
+public class UserService extends ServiceImpl<UserMapper, User> {
+    
+    /**
+     * 方案1：使用 updateById（默认不更新null字段）
+     * 问题：字段为null时不会更新到数据库
+     */
+    public boolean updateByIdDefault(User user) {
+        // 默认情况下，null字段不会被更新
+        return updateById(user);
+    }
+    
+    /**
+     * 方案2：使用 UpdateWrapper 显式设置null值
+     * 优点：可以精确控制哪些字段设置为null
+     */
+    public boolean updateByWrapperWithNull(Long id, User user) {
+        UpdateWrapper<User> wrapper = new UpdateWrapper<>();
+        wrapper.eq("id", id)
+                .set("username", user.getUsername())
+                .set("email", user.getEmail())  // 即使为null也会更新
+                .set("phone", user.getPhone())  // 即使为null也会更新
+                .set("address", user.getAddress())
+                .set("age", user.getAge())
+                .set("status", user.getStatus());
+        
+        return update(wrapper);
+    }
+    
+    /**
+     * 方案3：使用 LambdaUpdateWrapper（推荐）
+     * 优点：类型安全，可以精确控制每个字段
+     */
+    public boolean updateByLambdaWrapper(Long id, User user) {
+        LambdaUpdateWrapper<User> wrapper = Wrappers.<User>lambdaUpdate()
+                .eq(User::getId, id)
+                .set(User::getUsername, user.getUsername())
+                .set(User::getEmail, user.getEmail())  // 即使为null也会更新
+                .set(User::getPhone, user.getPhone())  // 即使为null也会更新
+                .set(User::getAddress, user.getAddress())
+                .set(User::getAge, user.getAge())
+                .set(User::getStatus, user.getStatus());
+        
+        return update(wrapper);
+    }
+    
+    /**
+     * 方案4：使用自定义SQL
+     * 优点：完全控制SQL语句
+     */
+    public boolean updateByCustomSql(User user) {
+        return baseMapper.updateByIdWithNull(user) > 0;
+    }
+    
+    /**
+     * 方案5：先查询再更新
+     * 缺点：需要两次数据库操作，性能较差
+     */
+    public boolean updateBySelectFirst(User updateUser) {
+        User dbUser = getById(updateUser.getId());
+        if (dbUser == null) {
+            return false;
+        }
+        
+        // 只更新传入的非null字段
+        if (updateUser.getUsername() != null) {
+            dbUser.setUsername(updateUser.getUsername());
+        }
+        // 如果需要将某个字段设置为null，需要特殊处理
+        // 例如：通过一个标志位或特殊值来表示需要设置为null
+        if ("NULL".equals(updateUser.getEmail())) {
+            dbUser.setEmail(null);
+        } else if (updateUser.getEmail() != null) {
+            dbUser.setEmail(updateUser.getEmail());
+        }
+        
+        if (updateUser.getPhone() != null) {
+            dbUser.setPhone(updateUser.getPhone());
+        }
+        if (updateUser.getAddress() != null) {
+            dbUser.setAddress(updateUser.getAddress());
+        }
+        if (updateUser.getAge() != null) {
+            dbUser.setAge(updateUser.getAge());
+        }
+        if (updateUser.getStatus() != null) {
+            dbUser.setStatus(updateUser.getStatus());
+        }
+        
+        return updateById(dbUser);
+    }
+    
+    /**
+     * 方案6：使用 allEq 方法
+     * 可以控制null值的处理方式
+     */
+    public boolean updateByAllEq(Long id, User user) {
+        UpdateWrapper<User> wrapper = new UpdateWrapper<>();
+        wrapper.eq("id", id);
+        
+        // 构建更新字段的Map
+        java.util.Map<String, Object> updateMap = new java.util.HashMap<>();
+        updateMap.put("username", user.getUsername());
+        updateMap.put("email", user.getEmail());
+        updateMap.put("phone", user.getPhone());
+        updateMap.put("address", user.getAddress());
+        updateMap.put("age", user.getAge());
+        updateMap.put("status", user.getStatus());
+        
+        // allEq的第二个参数为true表示null值也会更新
+        wrapper.allEq(updateMap, true);
+        
+        return update(wrapper);
+    }
+    
+    /**
+     * 方案7：动态SQL更新
+     * 通过forceNull参数控制是否更新null值
+     */
+    public boolean updateDynamic(User user, boolean forceUpdateNull) {
+        return baseMapper.updateDynamic(user, forceUpdateNull) > 0;
+    }
+    
+    /**
+     * 清空某个字段（设置为null）
+     */
+    public boolean clearField(Long id, String fieldName) {
+        LambdaUpdateWrapper<User> wrapper = Wrappers.<User>lambdaUpdate()
+                .eq(User::getId, id);
+        
+        switch (fieldName) {
+            case "email":
+                wrapper.set(User::getEmail, null);
+                break;
+            case "phone":
+                wrapper.set(User::getPhone, null);
+                break;
+            case "address":
+                wrapper.set(User::getAddress, null);
+                break;
+            default:
+                return false;
+        }
+        
+        return update(wrapper);
+    }
+}

--- a/src/main/java/com/example/solutions/UpdateNullSolutionDemo.java
+++ b/src/main/java/com/example/solutions/UpdateNullSolutionDemo.java
@@ -1,0 +1,221 @@
+package com.example.solutions;
+
+import com.baomidou.mybatisplus.annotation.FieldStrategy;
+import com.baomidou.mybatisplus.annotation.TableField;
+import com.baomidou.mybatisplus.core.conditions.update.LambdaUpdateWrapper;
+import com.baomidou.mybatisplus.core.conditions.update.UpdateWrapper;
+import com.baomidou.mybatisplus.core.toolkit.Wrappers;
+import com.example.entity.User;
+
+/**
+ * MyBatis-Plus updateById null字段更新问题解决方案演示
+ * 
+ * @author AI Assistant
+ * @date 2024
+ */
+public class UpdateNullSolutionDemo {
+    
+    /**
+     * 问题说明：
+     * 
+     * 当使用 MyBatis-Plus 的 baseMapper.updateById(entity) 方法时，
+     * 如果实体对象的某些字段值为 null，这些字段不会被更新到数据库。
+     * 
+     * 原因：
+     * MyBatis-Plus 的默认字段更新策略是 FieldStrategy.NOT_NULL，
+     * 即只更新非 null 的字段。
+     */
+    
+    // ==================== 解决方案1：实体注解配置 ====================
+    
+    /**
+     * 在实体类的字段上使用 @TableField 注解
+     */
+    static class Solution1_EntityAnnotation {
+        
+        // 方式1：特定字段使用 IGNORED 策略（始终更新，包括null）
+        @TableField(updateStrategy = FieldStrategy.IGNORED)
+        private String alwaysUpdateField;
+        
+        // 方式2：特定字段使用 NOT_EMPTY 策略（非空字符串才更新）
+        @TableField(updateStrategy = FieldStrategy.NOT_EMPTY)
+        private String notEmptyField;
+        
+        // 方式3：默认策略 NOT_NULL（非null才更新）
+        private String defaultField;
+    }
+    
+    // ==================== 解决方案2：全局配置 ====================
+    
+    /**
+     * 在 application.yml 中配置全局策略：
+     * 
+     * mybatis-plus:
+     *   global-config:
+     *     db-config:
+     *       # 全局字段更新策略
+     *       update-strategy: not_null  # 可选值：ignored, not_null, not_empty
+     *       
+     * 策略说明：
+     * - ignored: 忽略判断，所有字段都更新（包括null）
+     * - not_null: 非NULL更新（默认）
+     * - not_empty: 非空更新（对于字符串类型，空字符串也不更新）
+     */
+    
+    // ==================== 解决方案3：使用 UpdateWrapper ====================
+    
+    public void solution3_UpdateWrapper(Long userId) {
+        // 方式1：使用 UpdateWrapper
+        UpdateWrapper<User> updateWrapper = new UpdateWrapper<>();
+        updateWrapper.eq("id", userId)
+                .set("email", null)      // 明确设置为null
+                .set("phone", null)      // 明确设置为null
+                .set("address", "新地址"); // 正常更新
+        
+        // 执行更新
+        // userService.update(updateWrapper);
+        
+        // 方式2：使用 LambdaUpdateWrapper（推荐，类型安全）
+        LambdaUpdateWrapper<User> lambdaWrapper = Wrappers.<User>lambdaUpdate()
+                .eq(User::getId, userId)
+                .set(User::getEmail, null)      // 明确设置为null
+                .set(User::getPhone, null)      // 明确设置为null
+                .set(User::getAddress, "新地址");
+        
+        // 执行更新
+        // userService.update(lambdaWrapper);
+    }
+    
+    // ==================== 解决方案4：自定义SQL ====================
+    
+    /**
+     * 在 Mapper 接口中定义自定义方法
+     */
+    interface CustomUpdateMapper {
+        
+        // 方式1：使用 @Update 注解
+        // @Update("UPDATE user SET email = #{email}, phone = #{phone} WHERE id = #{id}")
+        // int updateWithNull(@Param("id") Long id, 
+        //                   @Param("email") String email, 
+        //                   @Param("phone") String phone);
+        
+        // 方式2：使用 XML 配置
+        /*
+        <update id="updateWithNull">
+            UPDATE user 
+            SET email = #{email},
+                phone = #{phone},
+                update_time = NOW()
+            WHERE id = #{id}
+        </update>
+        */
+    }
+    
+    // ==================== 解决方案5：动态SQL ====================
+    
+    public void solution5_DynamicSQL(User user, boolean forceUpdateNull) {
+        LambdaUpdateWrapper<User> wrapper = Wrappers.<User>lambdaUpdate()
+                .eq(User::getId, user.getId());
+        
+        // 根据条件决定是否更新null值
+        if (user.getEmail() != null || forceUpdateNull) {
+            wrapper.set(User::getEmail, user.getEmail());
+        }
+        if (user.getPhone() != null || forceUpdateNull) {
+            wrapper.set(User::getPhone, user.getPhone());
+        }
+        if (user.getAddress() != null) {
+            wrapper.set(User::getAddress, user.getAddress());
+        }
+        
+        // 执行更新
+        // userService.update(wrapper);
+    }
+    
+    // ==================== 解决方案6：使用 allEq 方法 ====================
+    
+    public void solution6_AllEq(Long userId, User user) {
+        UpdateWrapper<User> wrapper = new UpdateWrapper<>();
+        wrapper.eq("id", userId);
+        
+        // 构建更新字段Map
+        java.util.Map<String, Object> updateMap = new java.util.HashMap<>();
+        updateMap.put("email", user.getEmail());
+        updateMap.put("phone", user.getPhone());
+        updateMap.put("address", user.getAddress());
+        
+        // allEq 第二个参数控制null值处理
+        // true: null值也会更新
+        // false: null值不更新（默认）
+        wrapper.allEq(updateMap, true);
+        
+        // 执行更新
+        // userService.update(wrapper);
+    }
+    
+    // ==================== 最佳实践建议 ====================
+    
+    /**
+     * 最佳实践建议：
+     * 
+     * 1. 场景选择：
+     *    - 偶尔需要更新null值：使用 UpdateWrapper/LambdaUpdateWrapper
+     *    - 某字段经常需要更新null：在实体字段上加 @TableField(updateStrategy = FieldStrategy.IGNORED)
+     *    - 全局都需要更新null：修改全局配置（慎用）
+     *    - 复杂业务逻辑：自定义SQL
+     * 
+     * 2. 性能考虑：
+     *    - UpdateWrapper 性能最好（单次数据库操作）
+     *    - 避免先查后更（两次数据库操作）
+     *    - 批量更新时考虑使用批处理
+     * 
+     * 3. 安全性：
+     *    - 谨慎使用全局 IGNORED 策略，可能导致意外的null更新
+     *    - 使用 LambdaUpdateWrapper 避免字段名拼写错误
+     *    - 明确区分"不更新"和"更新为null"的业务场景
+     * 
+     * 4. 代码规范：
+     *    - 统一团队内的处理方式
+     *    - 在方法注释中说明null值的处理策略
+     *    - 对于重要字段，添加单元测试验证null更新行为
+     */
+    
+    // ==================== 常见错误示例 ====================
+    
+    public static class CommonMistakes {
+        
+        /**
+         * 错误示例1：期望updateById更新null值
+         */
+        public void mistake1_ExpectNullUpdate() {
+            User user = new User();
+            user.setId(1L);
+            user.setEmail(null);  // 期望更新为null，但实际不会更新
+            
+            // baseMapper.updateById(user);  // email字段不会被更新！
+        }
+        
+        /**
+         * 错误示例2：混淆空字符串和null
+         */
+        public void mistake2_EmptyStringVsNull() {
+            User user = new User();
+            user.setId(1L);
+            user.setEmail("");  // 空字符串会被更新
+            // user.setEmail(null);  // null不会被更新（默认策略）
+            
+            // baseMapper.updateById(user);
+        }
+        
+        /**
+         * 错误示例3：忘记设置更新条件
+         */
+        public void mistake3_NoCondition() {
+            UpdateWrapper<User> wrapper = new UpdateWrapper<>();
+            wrapper.set("email", null);  // 设置更新内容
+            // 忘记设置WHERE条件，会更新所有记录！
+            
+            // userService.update(wrapper);  // 危险：更新所有记录
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,33 @@
+spring:
+  datasource:
+    # 使用H2内存数据库进行演示
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+    username: sa
+    password: 
+    
+    # MySQL配置示例（如果需要使用MySQL，取消注释下面的配置）
+    # url: jdbc:mysql://localhost:3306/test?useUnicode=true&characterEncoding=utf-8&serverTimezone=GMT%2B8
+    # driver-class-name: com.mysql.cj.jdbc.Driver
+    # username: root
+    # password: 123456
+
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+
+mybatis-plus:
+  configuration:
+    log-impl: org.apache.ibatis.logging.stdout.StdOutImpl  # 打印SQL日志
+    map-underscore-to-camel-case: true
+  global-config:
+    db-config:
+      id-type: auto
+      # 全局更新策略配置
+      update-strategy: not_null  # 默认策略：NOT_NULL（只更新非null字段）
+      # update-strategy: ignored  # 如果设置为IGNORED，则会更新所有字段（包括null）
+
+logging:
+  level:
+    com.example.mapper: debug

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,21 @@
+-- 用户表
+CREATE TABLE IF NOT EXISTS user (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    username VARCHAR(50) NOT NULL,
+    password VARCHAR(100),
+    email VARCHAR(100),
+    phone VARCHAR(20),
+    address VARCHAR(200),
+    age INT,
+    status INT DEFAULT 1,
+    remark VARCHAR(500),
+    create_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    update_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    deleted INT DEFAULT 0
+);
+
+-- 插入测试数据
+INSERT INTO user (username, password, email, phone, address, age, status, remark) VALUES
+('张三', '123456', 'zhangsan@example.com', '13800138000', '北京市朝阳区', 25, 1, '测试用户1'),
+('李四', '123456', 'lisi@example.com', '13800138001', '上海市浦东新区', 30, 1, '测试用户2'),
+('王五', '123456', 'wangwu@example.com', '13800138002', '广州市天河区', 28, 1, '测试用户3');

--- a/src/test/java/com/example/UpdateNullFieldTest.java
+++ b/src/test/java/com/example/UpdateNullFieldTest.java
@@ -1,0 +1,248 @@
+package com.example;
+
+import com.baomidou.mybatisplus.core.conditions.update.LambdaUpdateWrapper;
+import com.baomidou.mybatisplus.core.toolkit.Wrappers;
+import com.example.entity.User;
+import com.example.mapper.UserMapper;
+import com.example.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * MyBatis-Plus updateById null字段更新测试
+ * 
+ * 问题描述：
+ * MyBatis-Plus 的 updateById 方法默认不会更新值为 null 的字段。
+ * 这是因为 MyBatis-Plus 的默认更新策略是 NOT_NULL。
+ * 
+ * 本测试类演示了多种解决方案。
+ */
+@SpringBootTest
+public class UpdateNullFieldTest {
+    
+    @Autowired
+    private UserService userService;
+    
+    @Autowired
+    private UserMapper userMapper;
+    
+    private Long testUserId;
+    
+    @BeforeEach
+    public void setUp() {
+        // 创建测试用户
+        User testUser = new User()
+                .setUsername("测试用户")
+                .setPassword("password")
+                .setEmail("test@example.com")
+                .setPhone("13800138888")
+                .setAddress("测试地址")
+                .setAge(20)
+                .setStatus(1);
+        
+        userService.save(testUser);
+        testUserId = testUser.getId();
+        System.out.println("创建测试用户，ID: " + testUserId);
+    }
+    
+    /**
+     * 测试1：默认的 updateById 不会更新 null 字段
+     */
+    @Test
+    public void testDefaultUpdateById() {
+        System.out.println("\n===== 测试1：默认updateById（不更新null字段）=====");
+        
+        // 尝试将email和phone设置为null
+        User updateUser = new User();
+        updateUser.setId(testUserId);
+        updateUser.setEmail(null);  // 设置为null
+        updateUser.setPhone(null);  // 设置为null
+        updateUser.setAddress("新地址");  // 正常更新
+        
+        // 执行更新
+        boolean success = userService.updateById(updateUser);
+        assertTrue(success);
+        
+        // 查询更新后的结果
+        User result = userService.getById(testUserId);
+        
+        // 验证：null字段没有被更新
+        System.out.println("更新后的email: " + result.getEmail());  // 仍然是原值
+        System.out.println("更新后的phone: " + result.getPhone());  // 仍然是原值
+        System.out.println("更新后的address: " + result.getAddress());  // 已更新
+        
+        assertNotNull(result.getEmail(), "email不应该被更新为null");
+        assertNotNull(result.getPhone(), "phone不应该被更新为null");
+        assertEquals("新地址", result.getAddress(), "address应该被更新");
+    }
+    
+    /**
+     * 测试2：使用 UpdateWrapper 可以更新 null 字段
+     */
+    @Test
+    public void testUpdateWrapperWithNull() {
+        System.out.println("\n===== 测试2：使用UpdateWrapper更新null字段 =====");
+        
+        // 使用UpdateWrapper显式设置null
+        LambdaUpdateWrapper<User> wrapper = Wrappers.<User>lambdaUpdate()
+                .eq(User::getId, testUserId)
+                .set(User::getEmail, null)  // 显式设置为null
+                .set(User::getPhone, null)  // 显式设置为null
+                .set(User::getAddress, "UpdateWrapper更新");
+        
+        boolean success = userService.update(wrapper);
+        assertTrue(success);
+        
+        // 查询更新后的结果
+        User result = userService.getById(testUserId);
+        
+        // 验证：字段已被更新为null
+        System.out.println("更新后的email: " + result.getEmail());  // null
+        System.out.println("更新后的phone: " + result.getPhone());  // null
+        System.out.println("更新后的address: " + result.getAddress());
+        
+        assertNull(result.getEmail(), "email应该被更新为null");
+        assertNull(result.getPhone(), "phone应该被更新为null");
+        assertEquals("UpdateWrapper更新", result.getAddress());
+    }
+    
+    /**
+     * 测试3：使用 @TableField 注解的 updateStrategy 属性
+     */
+    @Test
+    public void testTableFieldStrategy() {
+        System.out.println("\n===== 测试3：@TableField updateStrategy 策略 =====");
+        
+        User updateUser = new User();
+        updateUser.setId(testUserId);
+        updateUser.setEmail(null);  // 默认策略，不会更新
+        updateUser.setPhone(null);  // 设置了IGNORED策略，会更新为null
+        
+        boolean success = userService.updateById(updateUser);
+        assertTrue(success);
+        
+        User result = userService.getById(testUserId);
+        
+        System.out.println("email字段（默认策略）: " + result.getEmail());  // 不为null
+        System.out.println("phone字段（IGNORED策略）: " + result.getPhone());  // null
+        
+        assertNotNull(result.getEmail(), "email使用默认策略，不应该被更新为null");
+        assertNull(result.getPhone(), "phone使用IGNORED策略，应该被更新为null");
+    }
+    
+    /**
+     * 测试4：使用自定义SQL更新null字段
+     */
+    @Test
+    public void testCustomSqlUpdate() {
+        System.out.println("\n===== 测试4：使用自定义SQL更新null字段 =====");
+        
+        User updateUser = new User();
+        updateUser.setId(testUserId);
+        updateUser.setEmail(null);
+        updateUser.setPhone(null);
+        updateUser.setAddress("自定义SQL更新");
+        
+        int rows = userMapper.updateByIdWithNull(updateUser);
+        assertEquals(1, rows);
+        
+        User result = userService.getById(testUserId);
+        
+        System.out.println("更新后的email: " + result.getEmail());  // null
+        System.out.println("更新后的phone: " + result.getPhone());  // null
+        System.out.println("更新后的address: " + result.getAddress());
+        
+        assertNull(result.getEmail(), "email应该被更新为null");
+        assertNull(result.getPhone(), "phone应该被更新为null");
+        assertEquals("自定义SQL更新", result.getAddress());
+    }
+    
+    /**
+     * 测试5：使用Service层的封装方法
+     */
+    @Test
+    public void testServiceWrapperMethod() {
+        System.out.println("\n===== 测试5：使用Service封装的方法 =====");
+        
+        User updateUser = new User();
+        updateUser.setEmail(null);
+        updateUser.setPhone(null);
+        updateUser.setAddress("Service方法更新");
+        
+        boolean success = userService.updateByLambdaWrapper(testUserId, updateUser);
+        assertTrue(success);
+        
+        User result = userService.getById(testUserId);
+        
+        assertNull(result.getEmail(), "email应该被更新为null");
+        assertNull(result.getPhone(), "phone应该被更新为null");
+        assertEquals("Service方法更新", result.getAddress());
+    }
+    
+    /**
+     * 测试6：清空特定字段
+     */
+    @Test
+    public void testClearSpecificField() {
+        System.out.println("\n===== 测试6：清空特定字段 =====");
+        
+        // 清空email字段
+        boolean success = userService.clearField(testUserId, "email");
+        assertTrue(success);
+        
+        User result = userService.getById(testUserId);
+        assertNull(result.getEmail(), "email字段应该被清空");
+        assertNotNull(result.getPhone(), "phone字段不应该被影响");
+        
+        // 清空phone字段
+        success = userService.clearField(testUserId, "phone");
+        assertTrue(success);
+        
+        result = userService.getById(testUserId);
+        assertNull(result.getPhone(), "phone字段应该被清空");
+    }
+    
+    /**
+     * 打印解决方案总结
+     */
+    @Test
+    public void printSolutions() {
+        System.out.println("\n========== MyBatis-Plus updateById null字段更新解决方案总结 ==========\n");
+        
+        System.out.println("问题原因：");
+        System.out.println("- MyBatis-Plus 默认更新策略是 NOT_NULL");
+        System.out.println("- updateById 方法不会更新值为 null 的字段\n");
+        
+        System.out.println("解决方案：");
+        System.out.println("1. 【实体字段级别】使用 @TableField(updateStrategy = FieldStrategy.IGNORED)");
+        System.out.println("   - 优点：简单直接，针对特定字段");
+        System.out.println("   - 缺点：影响所有使用该实体的更新操作\n");
+        
+        System.out.println("2. 【全局配置】在 application.yml 中配置全局更新策略");
+        System.out.println("   mybatis-plus.global-config.db-config.update-strategy=ignored");
+        System.out.println("   - 优点：全局生效");
+        System.out.println("   - 缺点：可能导致意外的null更新\n");
+        
+        System.out.println("3. 【UpdateWrapper】使用 UpdateWrapper 或 LambdaUpdateWrapper");
+        System.out.println("   - 优点：灵活控制每个字段，类型安全");
+        System.out.println("   - 缺点：代码稍微复杂\n");
+        
+        System.out.println("4. 【自定义SQL】编写自定义的Mapper方法");
+        System.out.println("   - 优点：完全控制SQL");
+        System.out.println("   - 缺点：需要手写SQL\n");
+        
+        System.out.println("5. 【先查后更】先查询再更新");
+        System.out.println("   - 优点：逻辑清晰");
+        System.out.println("   - 缺点：性能较差，需要两次数据库操作\n");
+        
+        System.out.println("推荐方案：");
+        System.out.println("- 偶尔需要更新null：使用 UpdateWrapper");
+        System.out.println("- 特定字段总需要更新null：使用 @TableField 注解");
+        System.out.println("- 复杂业务逻辑：自定义SQL");
+        System.out.println("\n=====================================================");
+    }
+}


### PR DESCRIPTION
Create a Spring Boot project demonstrating and solving the MyBatis-Plus `updateById` null field update issue by providing multiple strategies.

MyBatis-Plus's `updateById` method defaults to a `NOT_NULL` update strategy, meaning fields with `null` values in the entity are ignored during an update. This PR illustrates this behavior and offers solutions like `@TableField(updateStrategy = FieldStrategy.IGNORED)`, `UpdateWrapper.set()`, custom SQL, and dynamic updates.

---
<a href="https://cursor.com/background-agent?bcId=bc-0cbe6514-4edc-4457-9a3a-72e33bed91d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0cbe6514-4edc-4457-9a3a-72e33bed91d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

