### PR TITLE
Fix null field update in baseMapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,167 @@
-# test
+# MyBatis-Plus baseMapper.updateById 字段为 null 未更新问题解决方案
+
+## 问题描述
+
+在使用 MyBatis-Plus 的 `baseMapper.updateById()` 方法时，如果实体对象的某个字段值为 `null`，该字段不会被更新到数据库中。这是 MyBatis-Plus 的默认行为。
+
+## 原因分析
+
+MyBatis-Plus 默认使用 `FieldStrategy.NOT_NULL` 策略，即只有非 null 的字段才会被包含在 UPDATE 语句中。这样设计是为了避免意外覆盖数据库中的有效数据。
+
+## 解决方案
+
+### 1. 【推荐】使用 @TableField 注解的 updateStrategy 属性
+
+在实体类字段上使用 `@TableField(updateStrategy = FieldStrategy.IGNORED)`：
+
+```java
+@TableField(value = "email", updateStrategy = FieldStrategy.IGNORED)
+private String email;
+```
+
+**优点**：简单直接，对特定字段生效  
+**缺点**：需要在实体类上修改，影响所有使用该实体的更新操作  
+**适用场景**：确定某个字段经常需要设置为 null 的情况
+
+### 2. 【推荐】使用 UpdateWrapper
+
+```java
+UpdateWrapper<User> updateWrapper = new UpdateWrapper<>();
+updateWrapper.eq("id", id);
+updateWrapper.set("email", null); // 强制设置为 null
+userService.update(updateWrapper);
+```
+
+**优点**：灵活性最高，可以精确控制每次更新的字段  
+**缺点**：代码稍微复杂一些  
+**适用场景**：需要动态控制更新字段的情况（推荐）
+
+### 3. 全局配置字段策略
+
+在 `application.yml` 中配置：
+
+```yaml
+mybatis-plus:
+  global-config:
+    db-config:
+      update-strategy: ignored
+```
+
+**优点**：一次配置，全局生效  
+**缺点**：影响范围太大，可能导致意外的数据覆盖  
+**适用场景**：项目中大部分更新操作都需要支持 null 值更新
+
+### 4. 使用自定义 SQL
+
+在 Mapper 中编写自定义的 UPDATE SQL 语句：
+
+```java
+@Update("UPDATE user SET email = #{email}, update_time = NOW() WHERE id = #{id}")
+int updateEmailById(@Param("id") Long id, @Param("email") String email);
+```
+
+**优点**：完全控制 SQL 语句，性能最优  
+**缺点**：需要编写和维护额外的 SQL 代码  
+**适用场景**：复杂的更新逻辑或性能要求很高的场景
+
+### 5. 先查询再更新
+
+```java
+User existingUser = userService.getById(id);
+existingUser.setEmail(null); // 设置需要更新的字段
+userService.updateById(existingUser);
+```
+
+**优点**：逻辑清晰，易于理解  
+**缺点**：需要额外的数据库查询，性能较差，存在并发问题  
+**适用场景**：更新频率不高，对性能要求不严格的场景
+
+## 项目结构
+
+```
+src/
+├── main/
+│   ├── java/com/example/demo/
+│   │   ├── entity/User.java              # 用户实体类（演示各种字段策略）
+│   │   ├── mapper/UserMapper.java        # 用户 Mapper 接口（自定义 SQL）
+│   │   ├── service/UserService.java      # 用户服务类（各种解决方案）
+│   │   ├── controller/UserController.java # 用户控制器（API 接口）
+│   │   ├── config/MybatisPlusConfig.java  # MyBatis-Plus 配置
+│   │   ├── NullUpdateSolutions.java      # 解决方案详细说明
+│   │   └── DemoApplication.java          # 主应用类
+│   └── resources/
+│       ├── application.yml               # 主配置文件
+│       └── schema.sql                    # 数据库表结构
+└── test/
+    ├── java/com/example/demo/
+    │   └── UserServiceTest.java          # 测试类（演示各种方案）
+    └── resources/
+        ├── application-test.yml          # 测试配置
+        └── schema.sql                    # 测试数据库表结构
+```
+
+## 运行项目
+
+### 1. 环境要求
+
+- JDK 8+
+- Maven 3.6+
+- MySQL 8.0+（生产环境）
+- H2 Database（测试环境，自动配置）
+
+### 2. 配置数据库
+
+修改 `src/main/resources/application.yml` 中的数据库连接信息：
+
+```yaml
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/demo
+    username: your_username
+    password: your_password
+```
+
+### 3. 运行应用
+
+```bash
+# 编译项目
+mvn clean compile
+
+# 运行测试
+mvn test
+
+# 启动应用
+mvn spring-boot:run
+```
+
+### 4. 测试 API
+
+应用启动后，可以通过以下 API 测试各种更新方案：
+
+- `POST /api/users` - 创建用户
+- `GET /api/users/{id}` - 获取用户
+- `PUT /api/users/{id}/standard` - 标准更新（null 值不更新）
+- `PUT /api/users/{id}/wrapper` - 使用 UpdateWrapper 更新
+- `PUT /api/users/{id}/force-all` - 强制更新所有字段
+- `PUT /api/users/{id}/description?description=` - 更新描述为 null
+- `PUT /api/users/{id}/query-update` - 先查询再更新
+
+## 推荐使用顺序
+
+1. **UpdateWrapper（方案2）** - 最灵活，适用于大多数场景
+2. **@TableField 注解（方案1）** - 适用于特定字段总是需要支持 null 更新
+3. **自定义 SQL（方案4）** - 适用于复杂更新逻辑
+4. **全局配置（方案3）** - 谨慎使用，适用于项目整体需求
+5. **先查询再更新（方案5）** - 不推荐，除非特殊情况
+
+## 注意事项
+
+1. 使用 `FieldStrategy.IGNORED` 时要谨慎，确保不会意外覆盖重要数据
+2. 全局配置 `update-strategy: ignored` 影响范围很大，建议在新项目开始时就确定策略
+3. 使用 UpdateWrapper 时，记得处理并发更新的问题
+4. 自定义 SQL 要注意 SQL 注入安全问题
+5. 在生产环境中，建议对关键字段的 null 值更新进行额外的业务逻辑验证
+
+## 总结
+
+对于 MyBatis-Plus 中 `baseMapper.updateById` 字段为 null 未更新的问题，推荐优先使用 **UpdateWrapper** 方案，它提供了最好的灵活性和控制力。对于经常需要设置为 null 的特定字段，可以在实体类上使用 `@TableField(updateStrategy = FieldStrategy.IGNORED)` 注解。

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 
+         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>mybatis-plus-null-update-demo</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <name>MyBatis-Plus Null Update Demo</name>
+    <description>演示如何解决 baseMapper.updateById 字段为 null 未更新的问题</description>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <spring.boot.version>2.7.0</spring.boot.version>
+        <mybatis.plus.version>3.5.2</mybatis.plus.version>
+    </properties>
+
+    <dependencies>
+        <!-- Spring Boot Starter -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+            <version>${spring.boot.version}</version>
+        </dependency>
+
+        <!-- Spring Boot Web -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>${spring.boot.version}</version>
+        </dependency>
+
+        <!-- MyBatis-Plus -->
+        <dependency>
+            <groupId>com.baomidou</groupId>
+            <artifactId>mybatis-plus-boot-starter</artifactId>
+            <version>${mybatis.plus.version}</version>
+        </dependency>
+
+        <!-- MySQL Driver -->
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>8.0.29</version>
+        </dependency>
+
+        <!-- H2 Database for testing -->
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>2.1.212</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Spring Boot Test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <version>${spring.boot.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.24</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring.boot.version}</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/demo/DemoApplication.java
+++ b/src/main/java/com/example/demo/DemoApplication.java
@@ -1,0 +1,15 @@
+package com.example.demo;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * 演示应用主类
+ */
+@SpringBootApplication
+public class DemoApplication {
+    
+    public static void main(String[] args) {
+        SpringApplication.run(DemoApplication.class, args);
+    }
+}

--- a/src/main/java/com/example/demo/NullUpdateSolutions.java
+++ b/src/main/java/com/example/demo/NullUpdateSolutions.java
@@ -1,0 +1,76 @@
+package com.example.demo;
+
+/**
+ * MyBatis-Plus baseMapper.updateById 字段为 null 未更新问题的解决方案
+ * 
+ * 问题描述：
+ * 在使用 MyBatis-Plus 的 baseMapper.updateById() 方法时，如果实体对象的某个字段值为 null，
+ * 该字段不会被更新到数据库中，这是 MyBatis-Plus 的默认行为。
+ * 
+ * 原因分析：
+ * MyBatis-Plus 默认使用 FieldStrategy.NOT_NULL 策略，即只有非 null 的字段才会被包含在 UPDATE 语句中。
+ * 这样设计是为了避免意外覆盖数据库中的有效数据。
+ * 
+ * 解决方案：
+ * 
+ * 1. 【推荐】使用 @TableField 注解的 updateStrategy 属性
+ *    在实体类字段上使用 @TableField(updateStrategy = FieldStrategy.IGNORED)
+ *    这样该字段的 null 值也会被更新到数据库
+ * 
+ * 2. 【推荐】使用 UpdateWrapper
+ *    UpdateWrapper<User> wrapper = new UpdateWrapper<>();
+ *    wrapper.eq("id", id).set("field_name", null);
+ *    userService.update(wrapper);
+ * 
+ * 3. 全局配置字段策略
+ *    在 application.yml 中配置：
+ *    mybatis-plus:
+ *      global-config:
+ *        db-config:
+ *          update-strategy: ignored
+ * 
+ * 4. 使用自定义 SQL
+ *    在 Mapper 中编写自定义的 UPDATE SQL 语句
+ * 
+ * 5. 先查询再更新
+ *    先查询出完整对象，然后设置需要更新的字段，再调用 updateById
+ * 
+ * 各方案对比：
+ * 
+ * 方案1 - @TableField(updateStrategy = FieldStrategy.IGNORED)：
+ * 优点：简单直接，对特定字段生效
+ * 缺点：需要在实体类上修改，影响所有使用该实体的更新操作
+ * 适用场景：确定某个字段经常需要设置为 null 的情况
+ * 
+ * 方案2 - UpdateWrapper：
+ * 优点：灵活性最高，可以精确控制每次更新的字段
+ * 缺点：代码稍微复杂一些
+ * 适用场景：需要动态控制更新字段的情况（推荐）
+ * 
+ * 方案3 - 全局配置：
+ * 优点：一次配置，全局生效
+ * 缺点：影响范围太大，可能导致意外的数据覆盖
+ * 适用场景：项目中大部分更新操作都需要支持 null 值更新
+ * 
+ * 方案4 - 自定义 SQL：
+ * 优点：完全控制 SQL 语句，性能最优
+ * 缺点：需要编写和维护额外的 SQL 代码
+ * 适用场景：复杂的更新逻辑或性能要求很高的场景
+ * 
+ * 方案5 - 先查询再更新：
+ * 优点：逻辑清晰，易于理解
+ * 缺点：需要额外的数据库查询，性能较差，存在并发问题
+ * 适用场景：更新频率不高，对性能要求不严格的场景
+ * 
+ * 推荐使用顺序：
+ * 1. UpdateWrapper（方案2）- 最灵活，适用于大多数场景
+ * 2. @TableField 注解（方案1）- 适用于特定字段总是需要支持 null 更新
+ * 3. 自定义 SQL（方案4）- 适用于复杂更新逻辑
+ * 4. 全局配置（方案3）- 谨慎使用，适用于项目整体需求
+ * 5. 先查询再更新（方案5）- 不推荐，除非特殊情况
+ */
+public class NullUpdateSolutions {
+    
+    // 这个类仅用于文档说明，不包含实际代码
+    
+}

--- a/src/main/java/com/example/demo/config/MybatisPlusConfig.java
+++ b/src/main/java/com/example/demo/config/MybatisPlusConfig.java
@@ -1,0 +1,46 @@
+package com.example.demo.config;
+
+import com.baomidou.mybatisplus.core.handlers.MetaObjectHandler;
+import com.baomidou.mybatisplus.extension.plugins.MybatisPlusInterceptor;
+import com.baomidou.mybatisplus.extension.plugins.inner.PaginationInnerInterceptor;
+import org.apache.ibatis.reflection.MetaObject;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.LocalDateTime;
+
+/**
+ * MyBatis-Plus 配置类
+ */
+@Configuration
+public class MybatisPlusConfig {
+    
+    /**
+     * 分页插件
+     */
+    @Bean
+    public MybatisPlusInterceptor mybatisPlusInterceptor() {
+        MybatisPlusInterceptor interceptor = new MybatisPlusInterceptor();
+        interceptor.addInnerInterceptor(new PaginationInnerInterceptor());
+        return interceptor;
+    }
+    
+    /**
+     * 自动填充处理器
+     */
+    @Bean
+    public MetaObjectHandler metaObjectHandler() {
+        return new MetaObjectHandler() {
+            @Override
+            public void insertFill(MetaObject metaObject) {
+                this.strictInsertFill(metaObject, "createTime", LocalDateTime.class, LocalDateTime.now());
+                this.strictInsertFill(metaObject, "updateTime", LocalDateTime.class, LocalDateTime.now());
+            }
+            
+            @Override
+            public void updateFill(MetaObject metaObject) {
+                this.strictUpdateFill(metaObject, "updateTime", LocalDateTime.class, LocalDateTime.now());
+            }
+        };
+    }
+}

--- a/src/main/java/com/example/demo/controller/UserController.java
+++ b/src/main/java/com/example/demo/controller/UserController.java
@@ -1,0 +1,77 @@
+package com.example.demo.controller;
+
+import com.example.demo.entity.User;
+import com.example.demo.service.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 用户控制器
+ * 演示各种更新方案的使用
+ */
+@RestController
+@RequestMapping("/api/users")
+public class UserController {
+    
+    @Autowired
+    private UserService userService;
+    
+    /**
+     * 创建用户
+     */
+    @PostMapping
+    public User createUser(@RequestBody User user) {
+        userService.save(user);
+        return user;
+    }
+    
+    /**
+     * 获取用户
+     */
+    @GetMapping("/{id}")
+    public User getUser(@PathVariable Long id) {
+        return userService.getById(id);
+    }
+    
+    /**
+     * 标准更新（null 值不会更新）
+     */
+    @PutMapping("/{id}/standard")
+    public boolean updateUserStandard(@PathVariable Long id, @RequestBody User user) {
+        user.setId(id);
+        return userService.updateById(user);
+    }
+    
+    /**
+     * 使用 UpdateWrapper 更新（推荐方案）
+     */
+    @PutMapping("/{id}/wrapper")
+    public boolean updateUserWithWrapper(@PathVariable Long id, @RequestBody User user) {
+        return userService.updateByIdWithWrapper(id, user);
+    }
+    
+    /**
+     * 强制更新所有字段（包括 null 值）
+     */
+    @PutMapping("/{id}/force-all")
+    public boolean updateUserForceAll(@PathVariable Long id, @RequestBody User user) {
+        user.setId(id);
+        return userService.updateByIdForceAll(user) > 0;
+    }
+    
+    /**
+     * 更新描述字段为 null
+     */
+    @PutMapping("/{id}/description")
+    public boolean updateDescription(@PathVariable Long id, @RequestParam(required = false) String description) {
+        return userService.updateDescriptionById(id, description) > 0;
+    }
+    
+    /**
+     * 先查询再更新
+     */
+    @PutMapping("/{id}/query-update")
+    public boolean updateUserWithQuery(@PathVariable Long id, @RequestBody User user) {
+        return userService.updateByIdWithQuery(id, user);
+    }
+}

--- a/src/main/java/com/example/demo/entity/User.java
+++ b/src/main/java/com/example/demo/entity/User.java
@@ -1,0 +1,68 @@
+package com.example.demo.entity;
+
+import com.baomidou.mybatisplus.annotation.*;
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import java.time.LocalDateTime;
+
+/**
+ * 用户实体类
+ * 演示 updateById 字段为 null 时未更新的问题
+ */
+@Data
+@Accessors(chain = true)
+@TableName("user")
+public class User {
+    
+    @TableId(value = "id", type = IdType.AUTO)
+    private Long id;
+    
+    /**
+     * 用户名 - 默认策略：NOT_NULL（null值不更新）
+     */
+    @TableField("username")
+    private String username;
+    
+    /**
+     * 邮箱 - 使用 IGNORED 策略（null值也会更新）
+     */
+    @TableField(value = "email", updateStrategy = FieldStrategy.IGNORED)
+    private String email;
+    
+    /**
+     * 手机号 - 使用 NOT_EMPTY 策略（null和空字符串都不更新）
+     */
+    @TableField(value = "phone", updateStrategy = FieldStrategy.NOT_EMPTY)
+    private String phone;
+    
+    /**
+     * 年龄 - 默认策略：NOT_NULL
+     */
+    @TableField("age")
+    private Integer age;
+    
+    /**
+     * 状态 - 使用 IGNORED 策略
+     */
+    @TableField(value = "status", updateStrategy = FieldStrategy.IGNORED)
+    private Integer status;
+    
+    /**
+     * 描述 - 可能需要设置为 null
+     */
+    @TableField("description")
+    private String description;
+    
+    /**
+     * 创建时间
+     */
+    @TableField(value = "create_time", fill = FieldFill.INSERT)
+    private LocalDateTime createTime;
+    
+    /**
+     * 更新时间
+     */
+    @TableField(value = "update_time", fill = FieldFill.INSERT_UPDATE)
+    private LocalDateTime updateTime;
+}

--- a/src/main/java/com/example/demo/mapper/UserMapper.java
+++ b/src/main/java/com/example/demo/mapper/UserMapper.java
@@ -1,0 +1,37 @@
+package com.example.demo.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.example.demo.entity.User;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Update;
+
+/**
+ * 用户 Mapper 接口
+ */
+@Mapper
+public interface UserMapper extends BaseMapper<User> {
+    
+    /**
+     * 自定义更新方法 - 强制更新所有字段（包括 null 值）
+     * 
+     * @param user 用户对象
+     * @return 影响行数
+     */
+    @Update("UPDATE user SET username = #{username}, email = #{email}, " +
+            "phone = #{phone}, age = #{age}, status = #{status}, " +
+            "description = #{description}, update_time = NOW() " +
+            "WHERE id = #{id}")
+    int updateByIdForceAll(@Param("user") User user);
+    
+    /**
+     * 自定义更新方法 - 只更新指定字段为 null
+     * 
+     * @param id 用户ID
+     * @param description 描述（可以为null）
+     * @return 影响行数
+     */
+    @Update("UPDATE user SET description = #{description}, update_time = NOW() " +
+            "WHERE id = #{id}")
+    int updateDescriptionById(@Param("id") Long id, @Param("description") String description);
+}

--- a/src/main/java/com/example/demo/service/UserService.java
+++ b/src/main/java/com/example/demo/service/UserService.java
@@ -1,0 +1,123 @@
+package com.example.demo.service;
+
+import com.baomidou.mybatisplus.core.conditions.update.UpdateWrapper;
+import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.example.demo.entity.User;
+import com.example.demo.mapper.UserMapper;
+import org.springframework.stereotype.Service;
+
+/**
+ * 用户服务类
+ * 演示多种解决 null 值更新的方案
+ */
+@Service
+public class UserService extends ServiceImpl<UserMapper, User> {
+    
+    /**
+     * 方案1：使用 UpdateWrapper 更新（推荐）
+     * 可以精确控制哪些字段需要更新，包括 null 值
+     * 
+     * @param id 用户ID
+     * @param user 要更新的用户信息
+     * @return 是否更新成功
+     */
+    public boolean updateByIdWithWrapper(Long id, User user) {
+        UpdateWrapper<User> updateWrapper = new UpdateWrapper<>();
+        updateWrapper.eq("id", id);
+        
+        // 使用 set 方法可以强制更新字段，即使值为 null
+        if (user.getUsername() != null) {
+            updateWrapper.set("username", user.getUsername());
+        }
+        
+        // 强制设置 email 为 null（如果需要）
+        updateWrapper.set("email", user.getEmail());
+        
+        if (user.getPhone() != null) {
+            updateWrapper.set("phone", user.getPhone());
+        }
+        
+        if (user.getAge() != null) {
+            updateWrapper.set("age", user.getAge());
+        }
+        
+        // 强制设置 status，即使为 null
+        updateWrapper.set("status", user.getStatus());
+        
+        // 强制设置 description，即使为 null
+        updateWrapper.set("description", user.getDescription());
+        
+        return this.update(updateWrapper);
+    }
+    
+    /**
+     * 方案2：使用 UpdateWrapper 的 setSql 方法
+     * 直接写 SQL 片段，完全控制更新逻辑
+     * 
+     * @param id 用户ID
+     * @param description 描述（可以为null）
+     * @return 是否更新成功
+     */
+    public boolean updateDescriptionToNull(Long id, String description) {
+        UpdateWrapper<User> updateWrapper = new UpdateWrapper<>();
+        updateWrapper.eq("id", id);
+        updateWrapper.setSql("description = '" + (description == null ? "NULL" : description) + "'");
+        
+        return this.update(updateWrapper);
+    }
+    
+    /**
+     * 方案3：使用自定义 Mapper 方法
+     * 
+     * @param user 用户对象
+     * @return 影响行数
+     */
+    public int updateByIdForceAll(User user) {
+        return baseMapper.updateByIdForceAll(user);
+    }
+    
+    /**
+     * 方案4：使用自定义 Mapper 方法更新特定字段
+     * 
+     * @param id 用户ID
+     * @param description 描述
+     * @return 影响行数
+     */
+    public int updateDescriptionById(Long id, String description) {
+        return baseMapper.updateDescriptionById(id, description);
+    }
+    
+    /**
+     * 方案5：先查询再更新（不推荐，但有时必要）
+     * 
+     * @param id 用户ID
+     * @param user 要更新的用户信息
+     * @return 是否更新成功
+     */
+    public boolean updateByIdWithQuery(Long id, User user) {
+        User existingUser = this.getById(id);
+        if (existingUser == null) {
+            return false;
+        }
+        
+        // 手动设置需要更新的字段
+        if (user.getUsername() != null) {
+            existingUser.setUsername(user.getUsername());
+        }
+        
+        // 强制更新为 null
+        existingUser.setEmail(user.getEmail());
+        existingUser.setStatus(user.getStatus());
+        existingUser.setDescription(user.getDescription());
+        
+        if (user.getPhone() != null) {
+            existingUser.setPhone(user.getPhone());
+        }
+        
+        if (user.getAge() != null) {
+            existingUser.setAge(user.getAge());
+        }
+        
+        return this.updateById(existingUser);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,53 @@
+# 主配置文件
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/demo?useUnicode=true&characterEncoding=utf8&useSSL=false&serverTimezone=Asia/Shanghai
+    username: root
+    password: password
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  
+  # JPA 配置
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+
+# MyBatis-Plus 配置
+mybatis-plus:
+  # 全局配置
+  global-config:
+    db-config:
+      # 主键类型：AUTO 自增
+      id-type: auto
+      # 字段策略：NOT_NULL 非空判断（默认值）
+      # 可选值：IGNORED（忽略）、NOT_NULL（非空）、NOT_EMPTY（非空且非空字符串）
+      insert-strategy: not_null
+      update-strategy: not_null
+      select-strategy: not_null
+      # 逻辑删除字段名
+      logic-delete-field: deleted
+      # 逻辑删除值
+      logic-delete-value: 1
+      # 逻辑未删除值
+      logic-not-delete-value: 0
+  
+  # 配置文件位置
+  mapper-locations: classpath*:/mapper/**/*.xml
+  
+  # 类型别名包扫描
+  type-aliases-package: com.example.demo.entity
+  
+  # 配置
+  configuration:
+    # 开启驼峰命名转换
+    map-underscore-to-camel-case: true
+    # 开启缓存
+    cache-enabled: true
+    # 打印 SQL
+    log-impl: org.apache.ibatis.logging.stdout.StdOutImpl
+
+# 日志配置
+logging:
+  level:
+    com.example.demo.mapper: debug
+    com.baomidou.mybatisplus: debug

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,13 @@
+-- 用户表
+CREATE TABLE IF NOT EXISTS `user` (
+    `id` BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '主键ID',
+    `username` VARCHAR(50) NOT NULL COMMENT '用户名',
+    `email` VARCHAR(100) COMMENT '邮箱',
+    `phone` VARCHAR(20) COMMENT '手机号',
+    `age` INT COMMENT '年龄',
+    `status` INT COMMENT '状态：0-禁用，1-启用',
+    `description` TEXT COMMENT '描述',
+    `create_time` DATETIME DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    `update_time` DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    `deleted` TINYINT DEFAULT 0 COMMENT '逻辑删除：0-未删除，1-已删除'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='用户表';

--- a/src/test/java/com/example/demo/UserServiceTest.java
+++ b/src/test/java/com/example/demo/UserServiceTest.java
@@ -1,0 +1,227 @@
+package com.example.demo;
+
+import com.example.demo.entity.User;
+import com.example.demo.service.UserService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * 用户服务测试类
+ * 演示各种 null 值更新解决方案
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+public class UserServiceTest {
+    
+    @Autowired
+    private UserService userService;
+    
+    /**
+     * 测试标准 updateById 方法（null 值不会更新）
+     */
+    @Test
+    public void testStandardUpdateById() {
+        // 创建用户
+        User user = new User()
+                .setUsername("testuser")
+                .setEmail("test@example.com")
+                .setPhone("13800138000")
+                .setAge(25)
+                .setStatus(1)
+                .setDescription("原始描述");
+        
+        userService.save(user);
+        Long userId = user.getId();
+        
+        // 尝试将某些字段更新为 null
+        User updateUser = new User()
+                .setId(userId)
+                .setUsername("newusername")
+                .setEmail(null)  // 尝试设置为 null
+                .setPhone("13900139000")
+                .setAge(null)    // 尝试设置为 null
+                .setStatus(null) // 尝试设置为 null（但实体类中配置了 IGNORED 策略）
+                .setDescription(null); // 尝试设置为 null
+        
+        // 执行更新
+        boolean result = userService.updateById(updateUser);
+        assertTrue(result);
+        
+        // 验证结果
+        User updatedUser = userService.getById(userId);
+        assertEquals("newusername", updatedUser.getUsername()); // 非 null 值被更新
+        assertEquals("test@example.com", updatedUser.getEmail()); // null 值未更新，保持原值
+        assertEquals("13900139000", updatedUser.getPhone()); // 非 null 值被更新
+        assertEquals(25, updatedUser.getAge()); // null 值未更新，保持原值
+        assertNull(updatedUser.getStatus()); // 配置了 IGNORED 策略，null 值被更新
+        assertEquals("原始描述", updatedUser.getDescription()); // null 值未更新，保持原值
+        
+        System.out.println("标准 updateById 测试完成：");
+        System.out.println("更新后的用户：" + updatedUser);
+    }
+    
+    /**
+     * 测试使用 UpdateWrapper 更新（推荐方案）
+     */
+    @Test
+    public void testUpdateWithWrapper() {
+        // 创建用户
+        User user = new User()
+                .setUsername("testuser2")
+                .setEmail("test2@example.com")
+                .setPhone("13800138001")
+                .setAge(30)
+                .setStatus(1)
+                .setDescription("原始描述2");
+        
+        userService.save(user);
+        Long userId = user.getId();
+        
+        // 使用 UpdateWrapper 更新
+        User updateUser = new User()
+                .setUsername("newusername2")
+                .setEmail(null)
+                .setPhone("13900139001")
+                .setAge(null)
+                .setStatus(null)
+                .setDescription(null);
+        
+        boolean result = userService.updateByIdWithWrapper(userId, updateUser);
+        assertTrue(result);
+        
+        // 验证结果
+        User updatedUser = userService.getById(userId);
+        assertEquals("newusername2", updatedUser.getUsername());
+        assertNull(updatedUser.getEmail()); // 使用 UpdateWrapper，null 值被更新
+        assertEquals("13900139001", updatedUser.getPhone());
+        assertNull(updatedUser.getAge()); // 使用 UpdateWrapper，null 值被更新
+        assertNull(updatedUser.getStatus());
+        assertNull(updatedUser.getDescription()); // 使用 UpdateWrapper，null 值被更新
+        
+        System.out.println("UpdateWrapper 测试完成：");
+        System.out.println("更新后的用户：" + updatedUser);
+    }
+    
+    /**
+     * 测试自定义 SQL 强制更新所有字段
+     */
+    @Test
+    public void testUpdateByIdForceAll() {
+        // 创建用户
+        User user = new User()
+                .setUsername("testuser3")
+                .setEmail("test3@example.com")
+                .setPhone("13800138002")
+                .setAge(35)
+                .setStatus(1)
+                .setDescription("原始描述3");
+        
+        userService.save(user);
+        Long userId = user.getId();
+        
+        // 使用自定义 SQL 强制更新所有字段
+        User updateUser = new User()
+                .setId(userId)
+                .setUsername("newusername3")
+                .setEmail(null)
+                .setPhone(null)
+                .setAge(null)
+                .setStatus(null)
+                .setDescription(null);
+        
+        int result = userService.updateByIdForceAll(updateUser);
+        assertEquals(1, result);
+        
+        // 验证结果
+        User updatedUser = userService.getById(userId);
+        assertEquals("newusername3", updatedUser.getUsername());
+        assertNull(updatedUser.getEmail()); // 自定义 SQL，null 值被更新
+        assertNull(updatedUser.getPhone()); // 自定义 SQL，null 值被更新
+        assertNull(updatedUser.getAge()); // 自定义 SQL，null 值被更新
+        assertNull(updatedUser.getStatus()); // 自定义 SQL，null 值被更新
+        assertNull(updatedUser.getDescription()); // 自定义 SQL，null 值被更新
+        
+        System.out.println("自定义 SQL 强制更新测试完成：");
+        System.out.println("更新后的用户：" + updatedUser);
+    }
+    
+    /**
+     * 测试更新特定字段为 null
+     */
+    @Test
+    public void testUpdateSpecificFieldToNull() {
+        // 创建用户
+        User user = new User()
+                .setUsername("testuser4")
+                .setEmail("test4@example.com")
+                .setPhone("13800138003")
+                .setAge(40)
+                .setStatus(1)
+                .setDescription("原始描述4");
+        
+        userService.save(user);
+        Long userId = user.getId();
+        
+        // 更新描述字段为 null
+        int result = userService.updateDescriptionById(userId, null);
+        assertEquals(1, result);
+        
+        // 验证结果
+        User updatedUser = userService.getById(userId);
+        assertEquals("testuser4", updatedUser.getUsername()); // 其他字段不变
+        assertEquals("test4@example.com", updatedUser.getEmail());
+        assertEquals("13800138003", updatedUser.getPhone());
+        assertEquals(40, updatedUser.getAge());
+        assertEquals(1, updatedUser.getStatus());
+        assertNull(updatedUser.getDescription()); // 描述字段被设置为 null
+        
+        System.out.println("更新特定字段为 null 测试完成：");
+        System.out.println("更新后的用户：" + updatedUser);
+    }
+    
+    /**
+     * 测试先查询再更新方案
+     */
+    @Test
+    public void testUpdateWithQuery() {
+        // 创建用户
+        User user = new User()
+                .setUsername("testuser5")
+                .setEmail("test5@example.com")
+                .setPhone("13800138004")
+                .setAge(45)
+                .setStatus(1)
+                .setDescription("原始描述5");
+        
+        userService.save(user);
+        Long userId = user.getId();
+        
+        // 使用先查询再更新的方案
+        User updateUser = new User()
+                .setUsername("newusername5")
+                .setEmail(null)
+                .setPhone("13900139004")
+                .setAge(null)
+                .setStatus(null)
+                .setDescription(null);
+        
+        boolean result = userService.updateByIdWithQuery(userId, updateUser);
+        assertTrue(result);
+        
+        // 验证结果
+        User updatedUser = userService.getById(userId);
+        assertEquals("newusername5", updatedUser.getUsername());
+        assertNull(updatedUser.getEmail()); // 先查询再更新，null 值被更新
+        assertEquals("13900139004", updatedUser.getPhone());
+        assertNull(updatedUser.getAge()); // 先查询再更新，null 值被更新
+        assertNull(updatedUser.getStatus());
+        assertNull(updatedUser.getDescription()); // 先查询再更新，null 值被更新
+        
+        System.out.println("先查询再更新测试完成：");
+        System.out.println("更新后的用户：" + updatedUser);
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,30 @@
+# 测试环境配置
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb
+    username: sa
+    password: 
+    driver-class-name: org.h2.Driver
+  
+  h2:
+    console:
+      enabled: true
+  
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+
+# MyBatis-Plus 测试配置
+mybatis-plus:
+  global-config:
+    db-config:
+      id-type: auto
+  configuration:
+    map-underscore-to-camel-case: true
+    log-impl: org.apache.ibatis.logging.stdout.StdOutImpl
+
+# 日志配置
+logging:
+  level:
+    com.example.demo: debug

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -1,0 +1,13 @@
+-- H2 数据库用户表
+CREATE TABLE IF NOT EXISTS `user` (
+    `id` BIGINT AUTO_INCREMENT PRIMARY KEY,
+    `username` VARCHAR(50) NOT NULL,
+    `email` VARCHAR(100),
+    `phone` VARCHAR(20),
+    `age` INT,
+    `status` INT,
+    `description` TEXT,
+    `create_time` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    `update_time` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    `deleted` TINYINT DEFAULT 0
+);


### PR DESCRIPTION
Add a demo project demonstrating five solutions for MyBatis-Plus `baseMapper.updateById` not updating null fields.

The default behavior of MyBatis-Plus's `updateById` is to ignore null fields to prevent accidental data loss. This PR provides a structured example with various approaches to explicitly set fields to null, including `@TableField` strategy, `UpdateWrapper`, global configuration, custom SQL, and a query-then-update method, along with their pros and cons.

---
<a href="https://cursor.com/background-agent?bcId=bc-5d76cf53-8992-49c9-af4b-ae3e4b79ebd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5d76cf53-8992-49c9-af4b-ae3e4b79ebd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

